### PR TITLE
:sparkles: added an example of how to simplify tiny-ewg even further

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,11 @@ add_executable(
   tiny-ewg
   "src/tiny-ewg.cpp"
 )
+
+add_executable(
+  tiny-ewg-improved
+  "src/tiny-ewg-improved.cpp"
+)
 # ----- end target definitions ----- # 
 
 # ----- begin copy across needed files ----- # 
@@ -65,6 +70,13 @@ ${CMAKE_CURRENT_BINARY_DIR}/kevin-bacon.dat
 
 add_custom_command(
 TARGET tiny-ewg POST_BUILD
+COMMAND ${CMAKE_COMMAND} -E copy
+${CMAKE_SOURCE_DIR}/src/tiny-ewg.txt
+${CMAKE_CURRENT_BINARY_DIR}/tiny-ewg.txt
+)
+
+add_custom_command(
+TARGET tiny-ewg-improved POST_BUILD
 COMMAND ${CMAKE_COMMAND} -E copy
 ${CMAKE_SOURCE_DIR}/src/tiny-ewg.txt
 ${CMAKE_CURRENT_BINARY_DIR}/tiny-ewg.txt

--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ Repository with notes and code examples for learning the Boost Graph Library.
     <td>A basic example of how to use Kruskals algorithm to find the MST. Taken from BGL library examples.</td>
   </tr>
   <tr>
-    <td>tiny-ewg.txt</td>
+    <td>tiny-ewg.cpp</td>
     <td>Reads in data from a textfile, creates a graph out of it and then finds the minimum spanning tree using Kruskal's algorithm</td>
+  </tr>
+  <tr>
+    <td>tiny-ewg-improved.cpp</td>
+    <td>Example by user sehe on stackexchange which makes some simplifications and improvements to the tiny-ewg example</td>
   </tr>
 </tbody>
 </table>

--- a/src/tiny-ewg-improved.cpp
+++ b/src/tiny-ewg-improved.cpp
@@ -1,0 +1,50 @@
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/graph_utility.hpp>
+#include <fstream>
+#include <iostream>
+
+//overload operator >> to ignore new lines
+struct NL_t {
+  friend std::istream& operator>>(std::istream& is, NL_t) {
+    return is.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  }
+} inline constexpr NL;
+
+using Graph = boost::adjacency_list<
+    boost::vecS, boost::vecS,boost::undirectedS,
+    boost::no_property,
+    boost::property<boost::edge_weight_t,double>>;
+using Vertex = boost::graph_traits<Graph>::vertex_descriptor;
+
+template<typename Graph, typename WeightMap>
+void printEdges(Graph const& g, WeightMap w) {
+  for (auto e : make_iterator_range(edges(g))) 
+      std::cout << e << " w: " << w[e] << "\n";
+}
+
+Graph read_ewg(std::string fname) {
+  std::ifstream datafile; //eats whitespace, tabs etc
+  datafile.exceptions(std::ios::failbit);
+  datafile.open(fname);
+
+  size_t nv = 0, ne = 0; 
+
+  // reads the number of nodes and the number of edges with overloaded NL that ignores newlines
+  datafile >> nv >> NL >> ne >> NL; 
+
+  Graph g(nv);
+  Vertex u, v;
+  double w;
+  while (ne-- && datafile >> u >> v >> w >> NL) 
+    /*auto [e,inserted] =*/add_edge(u,v,w,g);
+    
+  assert(nv == num_vertices(g));
+  return g;
+}
+
+int main() { 
+  auto g = read_ewg("tiny-ewg.txt"); 
+  //print_graph(g); //defined in boost/graph/graph_utility.hpp
+  auto weight_map = get(boost::edge_weight, g);
+  printEdges(g, weight_map);
+}


### PR DESCRIPTION
Added the example from the accepted answer of my post on stackexchange here:
https://stackoverflow.com/questions/77634022/how-to-set-custom-vertex-descriptor-to-own-value-using-add-vertex-boost-grap/77636497#77636497

A great example of how to simplify parts of the example 'tiny-ewg' even further. 